### PR TITLE
Add traffic light recognition msgs

### DIFF
--- a/autoware_auto_perception_msgs/CMakeLists.txt
+++ b/autoware_auto_perception_msgs/CMakeLists.txt
@@ -27,6 +27,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrackedObject.idl"
   "msg/TrackedObjectKinematics.idl"
   "msg/TrackedObjects.idl"
+  "msg/TrafficLight.idl"
+  "msg/TrafficSignal.idl"
+  "msg/TrafficSignalArray.idl"
   DEPENDENCIES
     "autoware_auto_geometry_msgs"
     "geometry_msgs"

--- a/autoware_auto_perception_msgs/CMakeLists.txt
+++ b/autoware_auto_perception_msgs/CMakeLists.txt
@@ -30,6 +30,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrafficLight.idl"
   "msg/TrafficSignal.idl"
   "msg/TrafficSignalArray.idl"
+  "msg/TrafficLightRoi.idl"
+  "msg/TrafficLightRoiArray.idl"
   DEPENDENCIES
     "autoware_auto_geometry_msgs"
     "geometry_msgs"

--- a/autoware_auto_perception_msgs/msg/TrafficLight.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLight.idl
@@ -1,0 +1,45 @@
+module autoware_auto_perception_msgs {
+  module msg {
+    @verbatim (language="comment", text=
+    " The following values are taken from the Vienna Convention on Road Traffic" "\n"
+    " with specific additional values for Japan." "\n"
+    " Source: https://en.wikipedia.org/wiki/Vienna_Convention_on_Road_Signs_and_Signals#Traffic_lights")
+    module TrafficLight_Color_Constants {
+      const uint8 UNKNOWN = 0;
+      const uint8 RED = 1;
+      const uint8 AMBER = 2;
+      const uint8 GREEN = 3;
+      const uint8 WHITE = 4;
+    };
+    module TrafficLight_Shape_Constants {
+      const uint8 UNKNOWN = 0;
+      const uint8 CIRCLE = 1;
+      const uint8 LEFT_ARROW = 2;
+      const uint8 RIGHT_ARROW = 3;
+      const uint8 UP_ARROW = 4;
+      const uint8 DOWN_ARROW = 5;
+      const uint8 DOWN_LEFT_ARROW = 6;
+      const uint8 DOWN_RIGHT_ARROW = 7;
+      const uint8 CROSS = 8;
+    };
+    module TrafficLight_Status_Constants {
+      const uint8 UNKNOWN = 0;
+      const uint8 SOLID_OFF = 1;
+      const uint8 SOLID_ON = 2;
+      const uint8 FLASHING = 3;
+    };
+    @verbatim (language="comment", text=
+    " A TrafficLight is defined here as a single light, indicator, or" "\n"
+    " bulb as opposed to a TrafficSignal which contains multiple TrafficLights.")
+    struct TrafficLight {
+      @default (value=0)
+      uint8 color;
+
+      @default (value=0)
+      uint8 shape;
+
+      @default (value=0)
+      uint8 status;
+    };
+  };
+};

--- a/autoware_auto_perception_msgs/msg/TrafficLight.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLight.idl
@@ -40,6 +40,9 @@ module autoware_auto_perception_msgs {
 
       @default (value=0)
       uint8 status;
+
+      @default (value=0.0)
+      float confidence;
     };
   };
 };

--- a/autoware_auto_perception_msgs/msg/TrafficLight.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLight.idl
@@ -1,36 +1,23 @@
 module autoware_auto_perception_msgs {
   module msg {
-    @verbatim (language="comment", text=
-    " The following values are taken from the Vienna Convention on Road Traffic" "\n"
-    " with specific additional values for Japan." "\n"
-    " Source: https://en.wikipedia.org/wiki/Vienna_Convention_on_Road_Signs_and_Signals#Traffic_lights")
-    module TrafficLight_Color_Constants {
-      const uint8 UNKNOWN = 0;
+    module TrafficLight_Constants {
       const uint8 RED = 1;
       const uint8 AMBER = 2;
       const uint8 GREEN = 3;
       const uint8 WHITE = 4;
+      const uint8 CIRCLE = 5;
+      const uint8 LEFT_ARROW = 6;
+      const uint8 RIGHT_ARROW = 7;
+      const uint8 UP_ARROW = 8;
+      const uint8 DOWN_ARROW = 9;
+      const uint8 DOWN_LEFT_ARROW = 10;
+      const uint8 DOWN_RIGHT_ARROW = 11;
+      const uint8 CROSS = 12;
+      const uint8 SOLID_OFF = 13;
+      const uint8 SOLID_ON = 14;
+      const uint8 FLASHING = 15;
+      const uint8 UNKNOWN = 16;
     };
-    module TrafficLight_Shape_Constants {
-      const uint8 UNKNOWN = 0;
-      const uint8 CIRCLE = 1;
-      const uint8 LEFT_ARROW = 2;
-      const uint8 RIGHT_ARROW = 3;
-      const uint8 UP_ARROW = 4;
-      const uint8 DOWN_ARROW = 5;
-      const uint8 DOWN_LEFT_ARROW = 6;
-      const uint8 DOWN_RIGHT_ARROW = 7;
-      const uint8 CROSS = 8;
-    };
-    module TrafficLight_Status_Constants {
-      const uint8 UNKNOWN = 0;
-      const uint8 SOLID_OFF = 1;
-      const uint8 SOLID_ON = 2;
-      const uint8 FLASHING = 3;
-    };
-    @verbatim (language="comment", text=
-    " A TrafficLight is defined here as a single light, indicator, or" "\n"
-    " bulb as opposed to a TrafficSignal which contains multiple TrafficLights.")
     struct TrafficLight {
       @default (value=0)
       uint8 color;

--- a/autoware_auto_perception_msgs/msg/TrafficLightRoi.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLightRoi.idl
@@ -1,0 +1,13 @@
+#include "sensor_msgs/msg/RegionOfInterest.idl"
+
+module autoware_auto_perception_msgs {
+  module msg {
+    @verbatim (language="comment", text="")
+    struct TrafficLightRoi {
+      @verbatim (language="comment", text="")
+
+      sensor_msgs::msg::RegionOfInterest roi;
+      int32 id;
+    };
+  };
+};

--- a/autoware_auto_perception_msgs/msg/TrafficLightRoi.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLightRoi.idl
@@ -2,10 +2,7 @@
 
 module autoware_auto_perception_msgs {
   module msg {
-    @verbatim (language="comment", text="")
     struct TrafficLightRoi {
-      @verbatim (language="comment", text="")
-
       sensor_msgs::msg::RegionOfInterest roi;
       int32 id;
     };

--- a/autoware_auto_perception_msgs/msg/TrafficLightRoiArray.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLightRoiArray.idl
@@ -3,12 +3,8 @@
 
 module autoware_auto_perception_msgs {
   module msg {
-    @verbatim (language="comment", text="")
     struct TrafficLightRoiArray {
-      @verbatim (language="comment", text="")
-
       std_msgs::msg::Header header;
-
       sequence<autoware_auto_perception_msgs::msg::TrafficLightRoi> rois;
     };
   };

--- a/autoware_auto_perception_msgs/msg/TrafficLightRoiArray.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLightRoiArray.idl
@@ -1,0 +1,15 @@
+#include "autoware_auto_perception_msgs/msg/TrafficLightRoi.idl"
+#include "std_msgs/msg/Header.idl"
+
+module autoware_auto_perception_msgs {
+  module msg {
+    @verbatim (language="comment", text="")
+    struct TrafficLightRoiArray {
+      @verbatim (language="comment", text="")
+
+      std_msgs::msg::Header header;
+
+      sequence<autoware_auto_perception_msgs::msg::TrafficLightRoi> rois;
+    };
+  };
+};

--- a/autoware_auto_perception_msgs/msg/TrafficSignal.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficSignal.idl
@@ -1,0 +1,19 @@
+#include "autoware_auto_perception_msgs/msg/TrafficLight.idl"
+
+module autoware_auto_perception_msgs {
+  module msg {
+    @verbatim (language="comment", text=
+    " A TrafficSignal is defined here as a group of multiple TrafficLights" "\n"
+    " which each represent a single light, indicator, or bulb.")
+    struct TrafficSignal {
+      @verbatim (language="comment", text=
+        " A value of 0 indicates an invalid map_primitive_id. Signals which are not"
+        " associated with map primitives should not be used in planning because this"
+        " indicates that the required signal-to-lane mapping is not available.")
+      @default (value=0)
+      int32 map_primitive_id;
+
+      sequence<autoware_auto_perception_msgs::msg::TrafficLight, 10> lights;
+    };
+  };
+};

--- a/autoware_auto_perception_msgs/msg/TrafficSignalArray.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficSignalArray.idl
@@ -1,0 +1,11 @@
+#include "autoware_auto_perception_msgs/msg/TrafficSignal.idl"
+#include "builtin_interfaces/msg/Time.idl"
+
+module autoware_auto_perception_msgs {
+  module msg {
+    struct TrafficSignalArray {
+      builtin_interfaces::msg::Time timestamp;
+      sequence<autoware_auto_perception_msgs::msg::TrafficSignal> signals;
+    };
+  };
+};

--- a/autoware_auto_perception_msgs/msg/TrafficSignalArray.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficSignalArray.idl
@@ -1,10 +1,10 @@
 #include "autoware_auto_perception_msgs/msg/TrafficSignal.idl"
-#include "builtin_interfaces/msg/Time.idl"
+#include "std_msgs/msg/Header.idl"
 
 module autoware_auto_perception_msgs {
   module msg {
     struct TrafficSignalArray {
-      builtin_interfaces::msg::Time timestamp;
+      std_msgs::msg::Header header;
       sequence<autoware_auto_perception_msgs::msg::TrafficSignal> signals;
     };
   };


### PR DESCRIPTION
Adding messages for traffic light recognition.

TrafficLight, TrafficSignal, TrafficSignalArray are used to contain traffic light clasification results. these are almost the same as [Autoware.Auto proposal](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/16) . 

TrafficLightRoi and TrafficLightRoiArray for traffic light detection haven't proposed on Autoware.Auto, so these are ported from  [AutowareArchitectureProposal](https://github.com/tier4/AutowareArchitectureProposal_msgs/tree/main/autoware_perception_msgs/msg/traffic_light_recognition)