### PR TITLE
fix symbol lookup error of  TrafficLightRoi

### DIFF
--- a/autoware_auto_perception_msgs/CMakeLists.txt
+++ b/autoware_auto_perception_msgs/CMakeLists.txt
@@ -35,6 +35,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES
     "autoware_auto_geometry_msgs"
     "geometry_msgs"
+    "sensor_msgs"
     "std_msgs"
   ADD_LINTER_TESTS
 )

--- a/autoware_auto_perception_msgs/package.xml
+++ b/autoware_auto_perception_msgs/package.xml
@@ -13,6 +13,7 @@
 
   <depend>autoware_auto_geometry_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
Error when launching node with autoware_auto_perception_msgs, 
```
[lidar_centerpoint_node-1] /home/yusuke/auto_workspace/autoware.proj/install/lidar_centerpoint/lib/lidar_centerpoint/lidar_centerpoint_node: symbol lookup error: /home/yusuke/auto_workspace/autoware.proj/install/autoware_auto_perception_msgs/lib/libautoware_auto_perception_msgs__rosidl_typesupport_introspection_cpp.so: undefined symbol: _ZN36rosidl_typesupport_introspection_cpp31get_message_type_support_handleIN11sensor_msgs3msg17RegionOfInterest_ISaIvEEEEEPK29rosidl_message_type_support_tv
```