### PR TITLE
[autoware_auto_vehicle_msgs] add message types

### DIFF
--- a/autoware_auto_vehicle_msgs/CMakeLists.txt
+++ b/autoware_auto_vehicle_msgs/CMakeLists.txt
@@ -9,7 +9,10 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/ControlModeCommand.idl"
+  "msg/ControlModeReport.idl"
   "msg/Engage.idl"
+  "msg/GearCommand.idl"
   "msg/GearReport.idl"
   "msg/HandBrakeCommand.idl"
   "msg/HandBrakeReport.idl"
@@ -20,6 +23,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/HornCommand.idl"
   "msg/HornReport.idl"
   "msg/StationaryLockingCommand.idl"
+  "msg/SteeringReport.idl"
   "msg/TurnIndicatorsCommand.idl"
   "msg/TurnIndicatorsReport.idl"
   "msg/VehicleControlCommand.idl"
@@ -27,6 +31,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VehicleOdometry.idl"
   "msg/VehicleStateCommand.idl"
   "msg/VehicleStateReport.idl"
+  "msg/VelocityReport.idl"
   "msg/WheelEncoder.idl"
   "msg/WipersCommand.idl"
   "msg/WipersReport.idl"

--- a/autoware_auto_vehicle_msgs/msg/ControlModeCommand.idl
+++ b/autoware_auto_vehicle_msgs/msg/ControlModeCommand.idl
@@ -1,0 +1,19 @@
+#include "builtin_interfaces/msg/Time.idl"
+
+module autoware_auto_vehicle_msgs {
+  module msg {
+    module ControlModeCommand_Constants {
+      const uint8 NO_COMMAND = 0;
+      const uint8 AUTONOMOUS = 1;
+      const uint8 MANUAL = 2;
+    };
+    @verbatim (language="comment", text=
+      " ControlModeCommand.msg")
+    struct ControlModeCommand {
+      builtin_interfaces::msg::Time stamp;
+
+      @default (value=0)
+      uint8 mode;
+    };
+  };
+};

--- a/autoware_auto_vehicle_msgs/msg/ControlModeReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/ControlModeReport.idl
@@ -1,0 +1,22 @@
+#include "builtin_interfaces/msg/Time.idl"
+
+module autoware_auto_vehicle_msgs {
+  module msg {
+    module ControlModeReport_Constants {
+      const uint8 NO_COMMAND = 0;
+      const uint8 AUTONOMOUS = 1;
+      const uint8 MANUAL = 2;
+      const uint8 DISENGAGED = 3;
+      const uint8 NOT_READY = 4;
+    };
+    @verbatim (language="comment", text=
+      " ControlModeReport.msg")
+
+    struct ControlModeReport {
+      builtin_interfaces::msg::Time stamp;
+
+      @default (value=0)
+      uint8 mode;
+    };
+  };
+};

--- a/autoware_auto_vehicle_msgs/msg/GearCommand.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearCommand.idl
@@ -1,0 +1,38 @@
+#include "builtin_interfaces/msg/Time.idl"
+
+module autoware_auto_vehicle_msgs {
+  module msg {
+    module GearCommand_Constants {
+      const uint8 DRIVE = 1;
+      const uint8 DRIVE_2 = 2;
+      const uint8 DRIVE_3 = 3;
+      const uint8 DRIVE_4 = 4;
+      const uint8 DRIVE_5 = 5;
+      const uint8 DRIVE_6 = 6;
+      const uint8 DRIVE_7 = 7;
+      const uint8 DRIVE_8 = 8;
+      const uint8 DRIVE_9 = 9;
+      const uint8 DRIVE_10 = 10;
+      const uint8 DRIVE_11 = 11;
+      const uint8 DRIVE_12 = 12;
+      const uint8 DRIVE_13 = 13;
+      const uint8 DRIVE_14 = 14;
+      const uint8 DRIVE_15 = 15;
+      const uint8 DRIVE_16 = 16;
+      const uint8 DRIVE_17 = 17;
+      const uint8 DRIVE_18 = 18;
+      const uint8 REVERSE = 19;
+      const uint8 REVERSE_2 = 20;
+      const uint8 PARK = 21;
+      const uint8 LOW = 22;
+      const uint8 LOW_2 = 23;
+    };
+
+    struct GearCommand {
+      builtin_interfaces::msg::Time stamp;
+
+      @default (value=0)
+      uint8 command;
+    };
+  };
+};

--- a/autoware_auto_vehicle_msgs/msg/SteeringReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/SteeringReport.idl
@@ -1,0 +1,17 @@
+#include "builtin_interfaces/msg/Time.idl"
+
+module autoware_auto_vehicle_msgs {
+  module msg {
+    @verbatim (language="comment", text=
+      " SteeringReport.msg")
+    struct SteeringReport {
+      builtin_interfaces::msg::Time stamp;
+
+      @verbatim (language="comment", text=
+        " Desired angle of the steering tire in radians left (positive)"
+        " or right (negative) of center (0.0)")
+      @default (value=0.0)
+      float steering_tire_angle;
+    };
+  };
+};

--- a/autoware_auto_vehicle_msgs/msg/VelocityReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/VelocityReport.idl
@@ -1,0 +1,14 @@
+#include "builtin_interfaces/msg/Time.idl"
+
+module autoware_auto_vehicle_msgs {
+  module msg {
+    @verbatim (language="comment", text=
+      " VelocityReport.msg")
+    struct VelocityReport {
+      builtin_interfaces::msg::Time stamp;
+
+      @default (value=0.0)
+      float velocity;
+    };
+  };
+};


### PR DESCRIPTION
 - GearCommand：reportはあるのにcommandがないので追加
 - ControlModeCommand/Report：これだけVehicleStateCommand/Reportから分離されてなかったので分離
 - SteeringReport & VelocityReport：ステアと車速は別々で出すことになったので分離
