### PR TITLE
Change metapackage's dependency to `depend` from `exec_depend`

### DIFF
--- a/autoware_auto_msgs/package.xml
+++ b/autoware_auto_msgs/package.xml
@@ -9,13 +9,13 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>autoware_auto_control_msgs</exec_depend>
-  <exec_depend>autoware_auto_geometry_msgs</exec_depend>
-  <exec_depend>autoware_auto_mapping_msgs</exec_depend>
-  <exec_depend>autoware_auto_perception_msgs</exec_depend>
-  <exec_depend>autoware_auto_planning_msgs</exec_depend>
-  <exec_depend>autoware_auto_system_msgs</exec_depend>
-  <exec_depend>autoware_auto_vehicle_msgs</exec_depend>
+  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_auto_geometry_msgs</depend>
+  <depend>autoware_auto_mapping_msgs</depend>
+  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_auto_system_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Changed the dependency specification for the meta package `autoware_auto_msgs` from` exec_depend` to `depend` to simplify the package.xml for packages that depend on multiple` autoware_auto_FOO_msgs`.