### PR TITLE
Add `RawControlCommand.idl` to CMakeLists.txt

### DIFF
--- a/autoware_auto_vehicle_msgs/CMakeLists.txt
+++ b/autoware_auto_vehicle_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/HeadlightsReport.idl"
   "msg/HornCommand.idl"
   "msg/HornReport.idl"
+  "msg/RawControlCommand.idl"
   "msg/StationaryLockingCommand.idl"
   "msg/SteeringReport.idl"
   "msg/TurnIndicatorsCommand.idl"


### PR DESCRIPTION
Add `RawControlCommand` to the `CMakeLists.txt` file so that it is correctly built.