### PR TITLE
feat: add neutral mode to gear msgs

### DIFF
--- a/autoware_auto_vehicle_msgs/msg/GearCommand.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearCommand.idl
@@ -3,6 +3,7 @@
 module autoware_auto_vehicle_msgs {
   module msg {
     module GearCommand_Constants {
+      const uint8 NEUTRAL = 0;
       const uint8 DRIVE = 1;
       const uint8 DRIVE_2 = 2;
       const uint8 DRIVE_3 = 3;

--- a/autoware_auto_vehicle_msgs/msg/GearCommand.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearCommand.idl
@@ -3,30 +3,31 @@
 module autoware_auto_vehicle_msgs {
   module msg {
     module GearCommand_Constants {
-      const uint8 DRIVE = 1;
-      const uint8 DRIVE_2 = 2;
-      const uint8 DRIVE_3 = 3;
-      const uint8 DRIVE_4 = 4;
-      const uint8 DRIVE_5 = 5;
-      const uint8 DRIVE_6 = 6;
-      const uint8 DRIVE_7 = 7;
-      const uint8 DRIVE_8 = 8;
-      const uint8 DRIVE_9 = 9;
-      const uint8 DRIVE_10 = 10;
-      const uint8 DRIVE_11 = 11;
-      const uint8 DRIVE_12 = 12;
-      const uint8 DRIVE_13 = 13;
-      const uint8 DRIVE_14 = 14;
-      const uint8 DRIVE_15 = 15;
-      const uint8 DRIVE_16 = 16;
-      const uint8 DRIVE_17 = 17;
-      const uint8 DRIVE_18 = 18;
-      const uint8 REVERSE = 19;
-      const uint8 REVERSE_2 = 20;
-      const uint8 PARK = 21;
-      const uint8 LOW = 22;
-      const uint8 LOW_2 = 23;
-      const uint8 NEUTRAL = 24;
+      const uint8 NONE = 0;
+      const uint8 NEUTRAL = 1;
+      const uint8 DRIVE_1 = 2;
+      const uint8 DRIVE_2 = 3;
+      const uint8 DRIVE_3 = 4;
+      const uint8 DRIVE_4 = 5;
+      const uint8 DRIVE_5 = 6;
+      const uint8 DRIVE_6 = 7;
+      const uint8 DRIVE_7 = 8;
+      const uint8 DRIVE_8 = 9;
+      const uint8 DRIVE_9 = 10;
+      const uint8 DRIVE_10 = 11;
+      const uint8 DRIVE_11 = 12;
+      const uint8 DRIVE_12 = 13;
+      const uint8 DRIVE_13 = 14;
+      const uint8 DRIVE_14 = 15;
+      const uint8 DRIVE_15 = 16;
+      const uint8 DRIVE_16 = 17;
+      const uint8 DRIVE_17 = 18;
+      const uint8 DRIVE_18 = 19;
+      const uint8 REVERSE = 20;
+      const uint8 REVERSE_2 = 21;
+      const uint8 PARK = 22;
+      const uint8 LOW = 23;
+      const uint8 LOW_2 = 24;
     };
 
     struct GearCommand {

--- a/autoware_auto_vehicle_msgs/msg/GearCommand.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearCommand.idl
@@ -3,7 +3,6 @@
 module autoware_auto_vehicle_msgs {
   module msg {
     module GearCommand_Constants {
-      const uint8 NEUTRAL = 0;
       const uint8 DRIVE = 1;
       const uint8 DRIVE_2 = 2;
       const uint8 DRIVE_3 = 3;
@@ -27,6 +26,7 @@ module autoware_auto_vehicle_msgs {
       const uint8 PARK = 21;
       const uint8 LOW = 22;
       const uint8 LOW_2 = 23;
+      const uint8 NEUTRAL = 24;
     };
 
     struct GearCommand {

--- a/autoware_auto_vehicle_msgs/msg/GearReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearReport.idl
@@ -3,30 +3,31 @@
 module autoware_auto_vehicle_msgs {
   module msg {
     module GearReport_Constants {
-      const uint8 DRIVE = 1;
-      const uint8 DRIVE_2 = 2;
-      const uint8 DRIVE_3 = 3;
-      const uint8 DRIVE_4 = 4;
-      const uint8 DRIVE_5 = 5;
-      const uint8 DRIVE_6 = 6;
-      const uint8 DRIVE_7 = 7;
-      const uint8 DRIVE_8 = 8;
-      const uint8 DRIVE_9 = 9;
-      const uint8 DRIVE_10 = 10;
-      const uint8 DRIVE_11 = 11;
-      const uint8 DRIVE_12 = 12;
-      const uint8 DRIVE_13 = 13;
-      const uint8 DRIVE_14 = 14;
-      const uint8 DRIVE_15 = 15;
-      const uint8 DRIVE_16 = 16;
-      const uint8 DRIVE_17 = 17;
-      const uint8 DRIVE_18 = 18;
-      const uint8 REVERSE = 19;
-      const uint8 REVERSE_2 = 20;
-      const uint8 PARK = 21;
-      const uint8 LOW = 22;
-      const uint8 LOW_2 = 23;
-      const uint8 NEUTRAL = 24;
+      const uint8 NONE = 0;
+      const uint8 NEUTRAL = 1;
+      const uint8 DRIVE_1 = 2;
+      const uint8 DRIVE_2 = 3;
+      const uint8 DRIVE_3 = 4;
+      const uint8 DRIVE_4 = 5;
+      const uint8 DRIVE_5 = 6;
+      const uint8 DRIVE_6 = 7;
+      const uint8 DRIVE_7 = 8;
+      const uint8 DRIVE_8 = 9;
+      const uint8 DRIVE_9 = 10;
+      const uint8 DRIVE_10 = 11;
+      const uint8 DRIVE_11 = 12;
+      const uint8 DRIVE_12 = 13;
+      const uint8 DRIVE_13 = 14;
+      const uint8 DRIVE_14 = 15;
+      const uint8 DRIVE_15 = 16;
+      const uint8 DRIVE_16 = 17;
+      const uint8 DRIVE_17 = 18;
+      const uint8 DRIVE_18 = 19;
+      const uint8 REVERSE = 20;
+      const uint8 REVERSE_2 = 21;
+      const uint8 PARK = 22;
+      const uint8 LOW = 23;
+      const uint8 LOW_2 = 24;
     };
 
     struct GearReport {
@@ -37,4 +38,3 @@ module autoware_auto_vehicle_msgs {
     };
   };
 };
-

--- a/autoware_auto_vehicle_msgs/msg/GearReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearReport.idl
@@ -3,6 +3,7 @@
 module autoware_auto_vehicle_msgs {
   module msg {
     module GearReport_Constants {
+      const uint8 NEUTRAL = 0;
       const uint8 DRIVE = 1;
       const uint8 DRIVE_2 = 2;
       const uint8 DRIVE_3 = 3;

--- a/autoware_auto_vehicle_msgs/msg/GearReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearReport.idl
@@ -3,7 +3,6 @@
 module autoware_auto_vehicle_msgs {
   module msg {
     module GearReport_Constants {
-      const uint8 NEUTRAL = 0;
       const uint8 DRIVE = 1;
       const uint8 DRIVE_2 = 2;
       const uint8 DRIVE_3 = 3;
@@ -27,6 +26,7 @@ module autoware_auto_vehicle_msgs {
       const uint8 PARK = 21;
       const uint8 LOW = 22;
       const uint8 LOW_2 = 23;
+      const uint8 NEUTRAL = 24;
     };
 
     struct GearReport {


### PR DESCRIPTION
# Description
add neutral command for gear msgs

in some situation NUETRAL message is necessary. 

https://star4.slack.com/archives/GRUE57C30/p1640070272320000?thread_ts=1640067609.307000&cid=GRUE57C30

# Related Issue
https://github.com/autowarefoundation/autoware.universe/issues/1


