### PR TITLE
fix: gear msgs

### DIFF
--- a/autoware_auto_vehicle_msgs/msg/GearCommand.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearCommand.idl
@@ -5,7 +5,7 @@ module autoware_auto_vehicle_msgs {
     module GearCommand_Constants {
       const uint8 NONE = 0;
       const uint8 NEUTRAL = 1;
-      const uint8 DRIVE_1 = 2;
+      const uint8 DRIVE = 2;
       const uint8 DRIVE_2 = 3;
       const uint8 DRIVE_3 = 4;
       const uint8 DRIVE_4 = 5;

--- a/autoware_auto_vehicle_msgs/msg/GearReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/GearReport.idl
@@ -5,7 +5,7 @@ module autoware_auto_vehicle_msgs {
     module GearReport_Constants {
       const uint8 NONE = 0;
       const uint8 NEUTRAL = 1;
-      const uint8 DRIVE_1 = 2;
+      const uint8 DRIVE = 2;
       const uint8 DRIVE_2 = 3;
       const uint8 DRIVE_3 = 4;
       const uint8 DRIVE_4 = 5;


### PR DESCRIPTION
fix UNRULED name for gear
each command or report has no suffix name
so DRIVE_1 should be DRIVE

https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/70#note_791241743

NOTE:
autoware.iv use DRIVE instead of DRIVE_1

related pr:
https://github.com/tier4/autoware_auto_msgs/pull/27