### PR TITLE
fix(PredictedPath): remove capacity limit

### DIFF
--- a/autoware_auto_perception_msgs/msg/PredictedPath.idl
+++ b/autoware_auto_perception_msgs/msg/PredictedPath.idl
@@ -4,7 +4,7 @@
 module autoware_auto_perception_msgs {
   module msg {
     struct PredictedPath {
-      sequence<geometry_msgs::msg::Pose, 100> path;
+      sequence<geometry_msgs::msg::Pose> path;
 
       @verbatim (language="comment", text=
         " The time_step field defines the interval between consecutive pose predictions in the path array.")


### PR DESCRIPTION
Remove the capacity limit from the `path` field of the `PredictedPath` message.
This capacity was causing crashes in specific scenarios when using the `scenario_test_runner`.
See https://github.com/autowarefoundation/autoware.universe/issues/1049