### PR TITLE
refactor!: port missing enum in ControlMode from tier4 ControlMode msg

### DIFF
--- a/autoware_auto_vehicle_msgs/CMakeLists.txt
+++ b/autoware_auto_vehicle_msgs/CMakeLists.txt
@@ -37,6 +37,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/WipersCommand.idl"
   "msg/WipersReport.idl"
   "srv/AutonomyModeChange.idl"
+  "srv/ControlModeCommand.srv"
   DEPENDENCIES
     "autoware_auto_planning_msgs"
     "builtin_interfaces"

--- a/autoware_auto_vehicle_msgs/msg/ControlModeReport.idl
+++ b/autoware_auto_vehicle_msgs/msg/ControlModeReport.idl
@@ -5,9 +5,11 @@ module autoware_auto_vehicle_msgs {
     module ControlModeReport_Constants {
       const uint8 NO_COMMAND = 0;
       const uint8 AUTONOMOUS = 1;
-      const uint8 MANUAL = 2;
-      const uint8 DISENGAGED = 3;
-      const uint8 NOT_READY = 4;
+      const uint8 AUTONOMOUS_STEER_ONLY = 2;
+      const uint8 AUTONOMOUS_VELOCITY_ONLY = 3;
+      const uint8 MANUAL = 4;
+      const uint8 DISENGAGED = 5;
+      const uint8 NOT_READY = 6;
     };
     @verbatim (language="comment", text=
       " ControlModeReport.msg")

--- a/autoware_auto_vehicle_msgs/srv/ControlModeCommand.srv
+++ b/autoware_auto_vehicle_msgs/srv/ControlModeCommand.srv
@@ -1,0 +1,12 @@
+uint8 NO_COMMAND = 0
+uint8 AUTONOMOUS = 1
+uint8 AUTONOMOUS_STEER_ONLY = 2
+uint8 AUTONOMOUS_VELOCITY_ONLY = 3
+uint8 MANUAL = 4
+
+builtin_interfaces/Time stamp
+uint8 mode
+
+---
+
+bool success


### PR DESCRIPTION
 - Add enum in ControlModeReport to support options in Tier4's ControlMode
 - Add ControlModeCommand srv.

See https://github.com/autowarefoundation/autoware.universe/issues/1509 for the background.

For T4 issue tracking: https://tier4.atlassian.net/browse/T4PB-18987