### PR TITLE
feat(autoware_auto_planning_msgs): remove drivable_area and add left and right bound

### DIFF
--- a/autoware_auto_planning_msgs/msg/Path.idl
+++ b/autoware_auto_planning_msgs/msg/Path.idl
@@ -5,7 +5,7 @@
 module autoware_auto_planning_msgs {
   module msg {
     @verbatim (language = "comment", text=
-      "Contains a PathPoint path and an OccupancyGrid of drivable_area.")
+      "Contains a PathPoint path and left and right bound.")
     struct Path {
       std_msgs::msg::Header header;
       sequence<autoware_auto_planning_msgs::msg::PathPoint> points;

--- a/autoware_auto_planning_msgs/msg/Path.idl
+++ b/autoware_auto_planning_msgs/msg/Path.idl
@@ -9,7 +9,8 @@ module autoware_auto_planning_msgs {
     struct Path {
       std_msgs::msg::Header header;
       sequence<autoware_auto_planning_msgs::msg::PathPoint> points;
-      nav_msgs::msg::OccupancyGrid drivable_area;
+      sequence<geometry_msgs::msg::Point> left_bound;
+      sequence<geometry_msgs::msg::Point> right_bound;
     };
   };
 };

--- a/autoware_auto_planning_msgs/msg/PathWithLaneId.idl
+++ b/autoware_auto_planning_msgs/msg/PathWithLaneId.idl
@@ -5,7 +5,7 @@
 module autoware_auto_planning_msgs {
   module msg {
     @verbatim (language = "comment", text=
-      "Contains a PathPointWithLaneId path and left an right bound.")
+      "Contains a PathPointWithLaneId path and left and right bound.")
     struct PathWithLaneId {
       std_msgs::msg::Header header;
       sequence<autoware_auto_planning_msgs::msg::PathPointWithLaneId> points;

--- a/autoware_auto_planning_msgs/msg/PathWithLaneId.idl
+++ b/autoware_auto_planning_msgs/msg/PathWithLaneId.idl
@@ -5,7 +5,7 @@
 module autoware_auto_planning_msgs {
   module msg {
     @verbatim (language = "comment", text=
-      "Contains a PathPointWithLaneId path and an OccupancyGrid of drivable_area.")
+      "Contains a PathPointWithLaneId path and left an right bound.")
     struct PathWithLaneId {
       std_msgs::msg::Header header;
       sequence<autoware_auto_planning_msgs::msg::PathPointWithLaneId> points;

--- a/autoware_auto_planning_msgs/msg/PathWithLaneId.idl
+++ b/autoware_auto_planning_msgs/msg/PathWithLaneId.idl
@@ -9,7 +9,8 @@ module autoware_auto_planning_msgs {
     struct PathWithLaneId {
       std_msgs::msg::Header header;
       sequence<autoware_auto_planning_msgs::msg::PathPointWithLaneId> points;
-      nav_msgs::msg::OccupancyGrid drivable_area;
+      sequence<geometry_msgs::msg::Point> left_bound;
+      sequence<geometry_msgs::msg::Point> right_bound;
     };
   };
 };


### PR DESCRIPTION
Since autoware decided to use left and right bound instead of occupancy grid for drivable area, I removed drivable area and added left and right bound to Path and PathWithLanedId. 