### PR TITLE
fix(autoware_auto_planning_msgs): added action_msgs dependency

### DIFF
--- a/autoware_auto_planning_msgs/CMakeLists.txt
+++ b/autoware_auto_planning_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     "autoware_auto_geometry_msgs"
     "autoware_auto_mapping_msgs"
     "builtin_interfaces"
+    "action_msgs"
     "geometry_msgs"
     "nav_msgs"
     "std_msgs"

--- a/autoware_auto_planning_msgs/package.xml
+++ b/autoware_auto_planning_msgs/package.xml
@@ -14,6 +14,7 @@
   <depend>autoware_auto_geometry_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>builtin_interfaces</depend>
+  <depend>action_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
Added missing dependency:

https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/commit/a85138f3f4adcece4fe46bef4ef344dde4a5923d

Pointed out by @jspricke:

https://github.com/jspricke/ros-deb-builder-action/pull/2#issuecomment-1384057164

See https://github.com/autowarefoundation/autoware/issues/3222