### PR TITLE
Fix linter tests on humble

### DIFF
--- a/autoware_auto_vehicle_msgs/msg/WheelEncoder.idl
+++ b/autoware_auto_vehicle_msgs/msg/WheelEncoder.idl
@@ -8,7 +8,7 @@ module autoware_auto_vehicle_msgs {
       std_msgs::msg::Header header;
 
       @verbatim (language="comment", text=
-        " Negative speed values indicate rotation in the opposite " "\n"
+        " Negative speed values indicate rotation in the opposite" "\n"
         " direction of the normal direction of travel of the vehicle.")
       @default (value=0.0)
       float speed_mps;


### PR DESCRIPTION
Running colcon test on humble causes linter error:
```
    Code style divergence in file '/ws/build/autoware_auto_vehicle_msgs/rosidl_generator_c/autoware_auto_vehicle_msgs/msg/detail/wheel_encoder__struct.h':
    
    --- /ws/build/autoware_auto_vehicle_msgs/rosidl_generator_c/autoware_auto_vehicle_msgs/msg/detail/wheel_encoder__struct.h
    +++ /ws/build/autoware_auto_vehicle_msgs/rosidl_generator_c/autoware_auto_vehicle_msgs/msg/detail/wheel_encoder__struct.h.uncrustify
    @@ -31 +31 @@
    -  ///  Negative speed values indicate rotation in the opposite 
    +  ///  Negative speed values indicate rotation in the opposite
```

This PR removes this superfluous space causing this error.    
