### PR TITLE
build: remove unused `<depend>` in package.xml files

### DIFF
--- a/autoware_auto_control_msgs/package.xml
+++ b/autoware_auto_control_msgs/package.xml
@@ -12,7 +12,6 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>builtin_interfaces</depend>
-  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/autoware_auto_planning_msgs/CMakeLists.txt
+++ b/autoware_auto_planning_msgs/CMakeLists.txt
@@ -24,10 +24,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PathPointWithLaneId.idl"
   "srv/ModifyTrajectory.idl"
   DEPENDENCIES
-    "autoware_auto_geometry_msgs"
     "autoware_auto_mapping_msgs"
     "builtin_interfaces"
-    "action_msgs"
     "geometry_msgs"
     "nav_msgs"
     "std_msgs"

--- a/autoware_auto_planning_msgs/package.xml
+++ b/autoware_auto_planning_msgs/package.xml
@@ -11,10 +11,8 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>autoware_auto_geometry_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>builtin_interfaces</depend>
-  <depend>action_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>

--- a/autoware_auto_system_msgs/package.xml
+++ b/autoware_auto_system_msgs/package.xml
@@ -13,7 +13,6 @@
 
   <depend>builtin_interfaces</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
see https://github.com/autowarefoundation/autoware/issues/3468
To merge after https://github.com/autowarefoundation/autoware.universe/pull/3606 to avoid missing deps downstream.


