### PR TITLE
feat(autoware_auto_perception_msgs): Add traffic light occlusion msgs

### DIFF
--- a/autoware_auto_perception_msgs/CMakeLists.txt
+++ b/autoware_auto_perception_msgs/CMakeLists.txt
@@ -35,6 +35,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrafficSignalArray.idl"
   "msg/TrafficSignalStamped.idl"
   "msg/TrafficSignalWithJudge.idl"
+  "msg/TrafficLightOcclusion.idl"
+  "msg/TrafficLightOcclusionArray.idl"
   DEPENDENCIES
     "autoware_auto_geometry_msgs"
     "geometry_msgs"

--- a/autoware_auto_perception_msgs/msg/TrafficLightOcclusion.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLightOcclusion.idl
@@ -1,0 +1,10 @@
+module autoware_auto_perception_msgs {
+  module msg {
+    struct TrafficLightOcclusion {
+      @default (value=0)
+      int32 occlusion_ratio;
+      
+      int32 id;
+    };
+  };
+};

--- a/autoware_auto_perception_msgs/msg/TrafficLightOcclusionArray.idl
+++ b/autoware_auto_perception_msgs/msg/TrafficLightOcclusionArray.idl
@@ -1,0 +1,11 @@
+#include "autoware_auto_perception_msgs/msg/TrafficLightOcclusion.idl"
+#include "std_msgs/msg/Header.idl"
+
+module autoware_auto_perception_msgs {
+  module msg {
+    struct TrafficLightOcclusionArray {
+      std_msgs::msg::Header header;
+      sequence<autoware_auto_perception_msgs::msg::TrafficLightOcclusion> occlusion_ratios;
+    };
+  };
+};


### PR DESCRIPTION
Two messages are added in this PR for transferring traffic light occlusion ratios within perception nodes.