### PR TITLE
Add missing `#include`'s for used types `Pose` and `PoseWithCovariance`

### DIFF
--- a/autoware_auto_perception_msgs/msg/DetectedObjectKinematics.idl
+++ b/autoware_auto_perception_msgs/msg/DetectedObjectKinematics.idl
@@ -1,4 +1,5 @@
 #include "geometry_msgs/msg/Point.idl"
+#include "geometry_msgs/msg/PoseWithCovariance.idl"
 #include "geometry_msgs/msg/Quaternion.idl"
 #include "geometry_msgs/msg/TwistWithCovariance.idl"
 

--- a/autoware_auto_perception_msgs/msg/TrackedObjectKinematics.idl
+++ b/autoware_auto_perception_msgs/msg/TrackedObjectKinematics.idl
@@ -1,5 +1,6 @@
 #include "geometry_msgs/msg/AccelWithCovariance.idl"
 #include "geometry_msgs/msg/Point.idl"
+#include "geometry_msgs/msg/PoseWithCovariance.idl"
 #include "geometry_msgs/msg/Quaternion.idl"
 #include "geometry_msgs/msg/TwistWithCovariance.idl"
 

--- a/autoware_auto_planning_msgs/msg/TrajectoryPoint.idl
+++ b/autoware_auto_planning_msgs/msg/TrajectoryPoint.idl
@@ -1,4 +1,5 @@
 #include "builtin_interfaces/msg/Duration.idl"
+#include "geometry_msgs/msg/Pose.idl"
 
 module autoware_auto_planning_msgs {
   module msg {


### PR DESCRIPTION
Add missing includes for used types `Pose` and `PoseWithCovariance`. 
Noticed this in [Foxglove Studio](studio.foxglove.dev) when using autoware mcap files.
These `#include`'s are present in newer versions of the autoware idl [here](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_planning_msgs/msg/TrajectoryPoint.idl)